### PR TITLE
Fixes for semantic segmentation downloading & extracting

### DIFF
--- a/segmentation/download_sem_segm.sh
+++ b/segmentation/download_sem_segm.sh
@@ -5,15 +5,15 @@
 # furthermore requires mseg-api ( https://github.com/mseg-dataset/mseg-api ) which needs amoung other things pytorch.
 # (use gitbash for MS Windows)
 
-RVC_DOWNL_SEM_SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+RVC_SEM_SEG_SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # All data is downloaded to subfolders of RVC_DATA_DIR; if this is not defined: use the root dir + /datasets
 if [ -z "${RVC_DATA_DIR}" ]; then
-  RVC_DOWNL_SEM_TRG_DIR=${RVC_OID_SCRIPT_DIR}/../datasets/
+  RVC_DOWNL_SEM_TRG_DIR=${RVC_SEM_SEG_SCRIPT_DIR}/../datasets/
 else
   RVC_DOWNL_SEM_TRG_DIR=${RVC_DATA_DIR}/
 fi
 
-if [ ! -d $RVC_SEM_SEG_SCRIPT_DIR/mseg_api ]; then
+if [ ! -d "$RVC_SEM_SEG_SCRIPT_DIR/mseg_api" ]; then
   # getting defined version of mseg repo
   git -C $RVC_SEM_SEG_SCRIPT_DIR clone https://github.com/mseg-dataset/mseg-api.git $RVC_SEM_SEG_SCRIPT_DIR/mseg_api
   git -C $RVC_SEM_SEG_SCRIPT_DIR/mseg_api checkout 7e72a0f4cfb002786b10f2918ead916d0e2bc22d
@@ -21,16 +21,16 @@ if [ ! -d $RVC_SEM_SEG_SCRIPT_DIR/mseg_api ]; then
   pip install -e $RVC_SEM_SEG_SCRIPT_DIR/mseg_api
 fi
 
-${RVC_DOWNL_SEM_SCRIPT_DIR}/download_coco_pano.sh
+${RVC_SEM_SEG_SCRIPT_DIR}/download_coco_pano.sh
 mseg_download_ade20k.sh ${RVC_DOWNL_SEM_TRG_DIR}/ade20k
-${RVC_DOWNL_SEM_SCRIPT_DIR}/download_cityscapes_pano.sh ${RVC_DOWNL_SEM_TRG_DIR}/cityscapes
-${RVC_DOWNL_SEM_SCRIPT_DIR}/download_kitti_pano.sh ${RVC_DOWNL_SEM_TRG_DIR}/kitti
+${RVC_SEM_SEG_SCRIPT_DIR}/download_cityscapes_pano.sh ${RVC_DOWNL_SEM_TRG_DIR}/cityscapes
+${RVC_SEM_SEG_SCRIPT_DIR}/download_kitti_pano.sh ${RVC_DOWNL_SEM_TRG_DIR}/kitti
 
-pushd ${RVC_DOWNL_SEM_SCRIPT_DIR}/legacy/
+pushd ${RVC_SEM_SEG_SCRIPT_DIR}/legacy/
 python download_scannet.py -o ${RVC_DOWNL_SEM_TRG_DIR}/scannet --rob_task_data
 python download_viper.py ${RVC_DOWNL_SEM_TRG_DIR}/viper
 popd
 
-${RVC_DOWNL_SEM_SCRIPT_DIR}/download_wilddash2.sh ${RVC_DOWNL_SEM_TRG_DIR}/wilddash
+${RVC_SEM_SEG_SCRIPT_DIR}/download_wilddash2.sh ${RVC_DOWNL_SEM_TRG_DIR}/wilddash
 echo "Downloaded & extracted sem. segm. datasets to subfolders at ${RVC_DOWNL_SEM_TRG_DIR}"
 

--- a/segmentation/extract_and_cleanup_sem_segm.sh
+++ b/segmentation/extract_and_cleanup_sem_segm.sh
@@ -16,7 +16,7 @@ fi
 echo "Extracting RVC files and removing archive files in the process. This can take 24h+ depending on your hdd/cpu configuration!"
 read -p "This process will remove archives (zip/tar/tar.gz) once they are extracted. Proceed? [y/n] " -n 1 -r RVC_CONFIRM_EXTR
 echo    # move to a new line
-if [[ ! $RVC_CONFIRM_EXTR =~ ^[Yy]$ ]]
+if [[ ! $RVC_CONFIRM_EXTR =~ ^[Yy]$ ]]; then
   RVC_EXTR_ROOT_DIR=
   RVC_CONFIRM_EXTR=
   exit 1

--- a/segmentation/remap_sem_segm.sh
+++ b/segmentation/remap_sem_segm.sh
@@ -35,7 +35,7 @@ pushd $RVC_SEM_SEG_SCRIPT_DIR/../common
   python rvc_remap_dataset_mseg.py --orig_dname cityscapes-34 --orig_dataroot ${RVC_DATA_SRC_DIR}/cityscapes $RVC_COMMON_CONV_PARAMS
   python rvc_remap_dataset_mseg.py --orig_dname coco-panoptic-201 --orig_dataroot ${RVC_DATA_SRC_DIR}/coco --panoptic_json "${RVC_DATA_SRC_DIR}/coco/annotations/panoptic_{split}2017.json" $RVC_COMMON_CONV_PARAMS
   python rvc_remap_dataset_mseg.py --orig_dname kitti-34 --orig_dataroot ${RVC_DATA_SRC_DIR}/kitti $RVC_COMMON_CONV_PARAMS
-  python rvc_remap_dataset_mseg.py --orig_dname mapillary-public66 --orig_dataroot ${RVC_DATA_DIR}/mvs --convert_label_from_rgb $RVC_COMMON_CONV_PARAMS
+  python rvc_remap_dataset_mseg.py --orig_dname mapillary-public66 --orig_dataroot ${RVC_DATA_DIR}/mvd --convert_label_from_rgb $RVC_COMMON_CONV_PARAMS
   python rvc_remap_dataset_mseg.py --orig_dname scannet-41 --orig_dataroot ${RVC_DATA_SRC_DIR}/scannet/scannet_frames_25k $RVC_COMMON_CONV_PARAMS
 
   python rvc_remap_dataset_mseg.py --orig_dname viper-rvc-32 --orig_dataroot ${RVC_DATA_SRC_DIR}/viper --panoptic_json "${RVC_DATA_SRC_DIR}/viper/{split}/pano.json" $RVC_COMMON_CONV_PARAMS


### PR DESCRIPTION
It seems that the dev_kit contains some errors / typos which prevent running them out of the box.

1. In `download_sem_segm.sh` [`da11fe2`]:
1.1. Fixed error in setting paths [RVC_OID_SCRIPT_DIR is undefined, RVC_SEM_SEG_SCRIPT_DIR is undefined etc]
1.2. Fixed the check for existence of mseg_api [L16]
2. In `extract_and_cleanup_sem_segm.sh` [`241c615`]
2.1. Fixed error in if ... fi clause 